### PR TITLE
feat: Implement Expense Records CRUD API

### DIFF
--- a/internal/core/entity/finance/expenseRecord.go
+++ b/internal/core/entity/finance/expenseRecord.go
@@ -1,0 +1,126 @@
+package entity_finance
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ExpenseRecordRepositoryInterface defines the repository operations for ExpenseRecord.
+type ExpenseRecordRepositoryInterface interface {
+	CreateExpenseRecord(ctx context.Context, data *ExpenseRecord) (*ExpenseRecord, error)
+	GetExpenseRecordByID(ctx context.Context, id string) (*ExpenseRecord, error)
+	GetExpenseRecords(ctx context.Context) ([]ExpenseRecord, error)
+	GetExpenseRecordsByFilter(ctx context.Context, filter map[string]interface{}) ([]ExpenseRecord, error)
+	UpdateExpenseRecord(ctx context.Context, id string, data *ExpenseRecord) (*ExpenseRecord, error)
+	DeleteExpenseRecord(ctx context.Context, id string) error
+}
+
+// ExpenseRecordServiceInterface defines the service operations for ExpenseRecord.
+type ExpenseRecordServiceInterface interface {
+	CreateExpenseRecord(ctx context.Context, data *ExpenseRecord) (*ExpenseRecord, error)
+	GetExpenseRecordByID(ctx context.Context, id string) (*ExpenseRecord, error)
+	GetExpenseRecords(ctx context.Context) ([]ExpenseRecord, error)
+	GetExpenseRecordsByFilter(ctx context.Context, filter map[string]interface{}) ([]ExpenseRecord, error)
+	UpdateExpenseRecord(ctx context.Context, id string, data *ExpenseRecord) (*ExpenseRecord, error)
+	DeleteExpenseRecord(ctx context.Context, id string) error
+}
+
+// ExpenseRecord defines the structure for an expense record.
+type ExpenseRecord struct {
+	ID              string    `json:"id" bson:"_id,omitempty"` // Auto-generated
+	Category        string    `json:"category" bson:"category"`
+	Subcategory     string    `json:"subcategory,omitempty" bson:"subcategory,omitempty"`
+	DueDate         string    `json:"dueDate" bson:"dueDate"` // ISO 8601 (YYYY-MM-DD)
+	PaymentDate     *string   `json:"paymentDate,omitempty" bson:"paymentDate,omitempty"` // ISO 8601 (YYYY-MM-DD)
+	Amount          float64   `json:"amount" bson:"amount"`
+	BankPaidFrom    *string   `json:"bankPaidFrom,omitempty" bson:"bankPaidFrom,omitempty"`
+	CustomBankName  *string   `json:"customBankName,omitempty" bson:"customBankName,omitempty"`
+	Description     *string   `json:"description,omitempty" bson:"description,omitempty"`
+	IsRecurring     bool      `json:"isRecurring" bson:"isRecurring"`
+	RecurrenceCount *int      `json:"recurrenceCount,omitempty" bson:"recurrenceCount,omitempty"`
+	CreatedAt       time.Time `json:"createdAt,omitempty" bson:"createdAt,omitempty"`
+	UpdatedAt       time.Time `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
+	UserID          string    `json:"userId,omitempty" bson:"userId,omitempty"` // To associate with a user
+}
+
+// NewExpenseRecord creates a new ExpenseRecord with default values.
+// Required fields (category, dueDate, amount) must be set separately.
+func NewExpenseRecord(category, dueDate string, amount float64, userID string) *ExpenseRecord {
+	return &ExpenseRecord{
+		Category:    category,
+		DueDate:     dueDate,
+		Amount:      amount,
+		IsRecurring: false,
+		UserID:      userID,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+}
+
+// Validate checks the ExpenseRecord fields for correctness.
+func (er *ExpenseRecord) Validate() error {
+	if strings.TrimSpace(er.Category) == "" {
+		return errors.New("category is required")
+	}
+	if len(er.Category) > 100 {
+		return errors.New("category must not exceed 100 characters")
+	}
+
+	if er.Subcategory != "" && len(er.Subcategory) > 100 {
+		return errors.New("subcategory must not exceed 100 characters")
+	}
+
+	if _, err := time.Parse("2006-01-02", er.DueDate); err != nil {
+		return errors.New("dueDate must be in YYYY-MM-DD format")
+	}
+
+	if er.PaymentDate != nil && *er.PaymentDate != "" {
+		if _, err := time.Parse("2006-01-02", *er.PaymentDate); err != nil {
+			return errors.New("paymentDate must be in YYYY-MM-DD format if provided")
+		}
+	}
+
+	if er.Amount <= 0 {
+		return errors.New("amount must be greater than 0")
+	}
+
+	if er.PaymentDate != nil && *er.PaymentDate != "" {
+		if er.BankPaidFrom == nil || strings.TrimSpace(*er.BankPaidFrom) == "" {
+			return errors.New("bankPaidFrom is required if paymentDate is filled")
+		}
+	}
+
+	if er.BankPaidFrom != nil && *er.BankPaidFrom == "other" {
+		if er.CustomBankName == nil || strings.TrimSpace(*er.CustomBankName) == "" {
+			return errors.New("customBankName is required when bankPaidFrom is 'other'")
+		}
+	}
+    if er.CustomBankName != nil && len(*er.CustomBankName) > 100 {
+        return errors.New("customBankName must not exceed 100 characters")
+    }
+
+
+	if er.Description != nil && len(*er.Description) > 200 {
+		return errors.New("description must not exceed 200 characters")
+	}
+
+	if er.IsRecurring {
+		if er.RecurrenceCount == nil || *er.RecurrenceCount < 1 {
+			return errors.New("recurrenceCount must be at least 1 if isRecurring is true")
+		}
+	} else {
+		if er.RecurrenceCount != nil {
+			// Field should not be present if not recurring, or be explicitly nil/0
+			// Depending on how you want to enforce this.
+			// For now, let's say it's an error if it's set when not recurring.
+			// return errors.New("recurrenceCount should only be set if isRecurring is true")
+		}
+	}
+	if strings.TrimSpace(er.UserID) == "" {
+		return errors.New("userID is required")
+	}
+
+	return nil
+}

--- a/internal/core/entity/finance/expenseRecord_test.go
+++ b/internal/core/entity/finance/expenseRecord_test.go
@@ -1,0 +1,145 @@
+package entity_finance
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExpenseRecord_Validate(t *testing.T) {
+	validRecord := func() *ExpenseRecord {
+		return &ExpenseRecord{
+			Category:    "Food",
+			Subcategory: "Groceries",
+			DueDate:     time.Now().Format("2006-01-02"),
+			Amount:      50.00,
+			UserID:      "user123",
+			IsRecurring: false,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		er      *ExpenseRecord
+		wantErr bool
+		errText string
+	}{
+		{
+			name:    "Valid record",
+			er:      validRecord(),
+			wantErr: false,
+		},
+		{
+			name: "Missing Category",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.Category = ""
+				return r
+			}(),
+			wantErr: true,
+			errText: "category is required",
+		},
+		{
+			name: "Invalid DueDate format",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.DueDate = "01-02-2023" // Invalid format
+				return r
+			}(),
+			wantErr: true,
+			errText: "dueDate must be in YYYY-MM-DD format",
+		},
+		{
+			name: "Amount zero",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.Amount = 0
+				return r
+			}(),
+			wantErr: true,
+			errText: "amount must be greater than 0",
+		},
+		{
+			name: "Missing UserID",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.UserID = ""
+				return r
+			}(),
+			wantErr: true,
+			errText: "userID is required",
+		},
+		{
+			name: "Recurring but no RecurrenceCount",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.IsRecurring = true
+				r.RecurrenceCount = nil
+				return r
+			}(),
+			wantErr: true,
+			errText: "recurrenceCount must be at least 1 if isRecurring is true",
+		},
+		{
+			name: "Recurring with RecurrenceCount zero",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.IsRecurring = true
+				zero := 0
+				r.RecurrenceCount = &zero
+				return r
+			}(),
+			wantErr: true,
+			errText: "recurrenceCount must be at least 1 if isRecurring is true",
+		},
+		{
+			name: "Valid recurring record",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				r.IsRecurring = true
+				count := 12
+				r.RecurrenceCount = &count
+				return r
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "BankPaidFrom 'other' but no CustomBankName",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				paymentDate := time.Now().Format("2006-01-02")
+				r.PaymentDate = &paymentDate
+				otherBank := "other"
+				r.BankPaidFrom = &otherBank
+				r.CustomBankName = nil
+				return r
+			}(),
+			wantErr: true,
+			errText: "customBankName is required when bankPaidFrom is 'other'",
+		},
+		 {
+			name: "PaymentDate filled but BankPaidFrom missing",
+			er: func() *ExpenseRecord {
+				r := validRecord()
+				paymentDate := time.Now().Format("2006-01-02")
+				r.PaymentDate = &paymentDate
+				r.BankPaidFrom = nil
+				return r
+			}(),
+			wantErr: true,
+			errText: "bankPaidFrom is required if paymentDate is filled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.er.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExpenseRecord.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err.Error() != tt.errText {
+				t.Errorf("ExpenseRecord.Validate() error text = %q, want %q", err.Error(), tt.errText)
+			}
+		})
+	}
+}

--- a/internal/core/repository/finance/expenseRecord.go
+++ b/internal/core/repository/finance/expenseRecord.go
@@ -1,0 +1,142 @@
+package repository_finance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	entity_finance "github.com/Tomelin/dashfin-backend-app/internal/core/entity/finance"
+	"github.com/Tomelin/dashfin-backend-app/pkg/database"
+	"github.com/google/uuid"
+)
+
+// ExpenseRecordRepository handles database operations for ExpenseRecords.
+type ExpenseRecordRepository struct {
+	DB database.FirebaseDBInterface
+}
+
+// InitializeExpenseRecordRepository creates a new ExpenseRecordRepository.
+func InitializeExpenseRecordRepository(db database.FirebaseDBInterface) (entity_finance.ExpenseRecordRepositoryInterface, error) {
+	if db == nil {
+		return nil, errors.New("database is nil")
+	}
+	return &ExpenseRecordRepository{DB: db}, nil
+}
+
+// CreateExpenseRecord adds a new expense record to the database.
+func (r *ExpenseRecordRepository) CreateExpenseRecord(ctx context.Context, data *entity_finance.ExpenseRecord) (*entity_finance.ExpenseRecord, error) {
+	if data == nil {
+		return nil, errors.New("expense record data is nil")
+	}
+
+	// Generate ID and set timestamps
+	data.ID = uuid.NewString()
+	data.CreatedAt = time.Now()
+	data.UpdatedAt = time.Now()
+
+	_, err := r.DB.Create(ctx, data, "expenseRecords")
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// GetExpenseRecordByID retrieves an expense record by its ID.
+func (r *ExpenseRecordRepository) GetExpenseRecordByID(ctx context.Context, id string) (*entity_finance.ExpenseRecord, error) {
+	if id == "" {
+		return nil, errors.New("id is empty")
+	}
+
+	filters := map[string]interface{}{
+		"_id": id, // Assuming MongoDB/Firebase uses _id or similar for document ID
+	}
+
+	result, err := r.DB.GetByFilter(ctx, filters, "expenseRecords")
+	if err != nil {
+		return nil, err
+	}
+
+	var records []entity_finance.ExpenseRecord
+	if err := json.Unmarshal(result, &records); err != nil {
+		return nil, err
+	}
+
+	if len(records) == 0 {
+		return nil, errors.New("expense record not found")
+	}
+	return &records[0], nil
+}
+
+// GetExpenseRecords retrieves all expense records for the user in context (or all if no user context).
+func (r *ExpenseRecordRepository) GetExpenseRecords(ctx context.Context) ([]entity_finance.ExpenseRecord, error) {
+	// Potentially add filtering by UserID from context if available
+	// For now, gets all records.
+	// userID := ctx.Value("UserID").(string)
+	// filters := map[string]interface{}{
+	//  "userId": userID,
+	// }
+	// result, err := r.DB.GetByFilter(ctx, filters, "expenseRecords")
+
+	result, err := r.DB.Get(ctx, "expenseRecords")
+	if err != nil {
+		return nil, err
+	}
+
+	var records []entity_finance.ExpenseRecord
+	if err := json.Unmarshal(result, &records); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// GetExpenseRecordsByFilter retrieves expense records based on a filter.
+func (r *ExpenseRecordRepository) GetExpenseRecordsByFilter(ctx context.Context, filter map[string]interface{}) ([]entity_finance.ExpenseRecord, error) {
+	if filter == nil {
+		return nil, errors.New("filter data is nil")
+	}
+
+	// Ensure UserID from context is part of the filter if not admin
+	// userID := ctx.Value("UserID").(string)
+	// filter["userId"] = userID
+
+
+	result, err := r.DB.GetByFilter(ctx, filter, "expenseRecords")
+	if err != nil {
+		return nil, err
+	}
+
+	var records []entity_finance.ExpenseRecord
+	if err := json.Unmarshal(result, &records); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// UpdateExpenseRecord updates an existing expense record.
+func (r *ExpenseRecordRepository) UpdateExpenseRecord(ctx context.Context, id string, data *entity_finance.ExpenseRecord) (*entity_finance.ExpenseRecord, error) {
+	if id == "" {
+		return nil, errors.New("id is empty for update")
+	}
+	if data == nil {
+		return nil, errors.New("expense record data for update is nil")
+	}
+
+	data.UpdatedAt = time.Now()
+	// Ensure ID is not changed and UserID is consistent if those are rules.
+	// data.ID = id // Not needed if ID is part of the data struct and matches `id` argument.
+
+	err := r.DB.Update(ctx, id, data, "expenseRecords")
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// DeleteExpenseRecord removes an expense record from the database.
+func (r *ExpenseRecordRepository) DeleteExpenseRecord(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("id is empty for delete")
+	}
+	return r.DB.Delete(ctx, id, "expenseRecords")
+}

--- a/internal/core/repository/finance/expenseRecord_test.go
+++ b/internal/core/repository/finance/expenseRecord_test.go
@@ -1,0 +1,11 @@
+package repository_finance
+
+import (
+	"testing"
+)
+
+// Basic test structure. Full tests require mocking FirebaseDBInterface.
+func TestExpenseRecordRepository_Placeholder(t *testing.T) {
+	// TODO: Add actual tests with mocks
+	t.Log("Placeholder test for ExpenseRecordRepository. Further tests require DB mocking.")
+}

--- a/internal/core/service/finance/expenseRecord.go
+++ b/internal/core/service/finance/expenseRecord.go
@@ -1,0 +1,198 @@
+package service_finance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	entity_finance "github.com/Tomelin/dashfin-backend-app/internal/core/entity/finance"
+)
+
+// ExpenseRecordService provides business logic for expense records.
+type ExpenseRecordService struct {
+	Repo entity_finance.ExpenseRecordRepositoryInterface
+}
+
+// InitializeExpenseRecordService creates a new ExpenseRecordService.
+func InitializeExpenseRecordService(repo entity_finance.ExpenseRecordRepositoryInterface) (entity_finance.ExpenseRecordServiceInterface, error) {
+	if repo == nil {
+		return nil, errors.New("repository is nil for ExpenseRecordService")
+	}
+	return &ExpenseRecordService{Repo: repo}, nil
+}
+
+// CreateExpenseRecord handles the creation of a new expense record.
+func (s *ExpenseRecordService) CreateExpenseRecord(ctx context.Context, data *entity_finance.ExpenseRecord) (*entity_finance.ExpenseRecord, error) {
+	if data == nil {
+		return nil, errors.New("expense record data is nil")
+	}
+
+	if err := data.Validate(); err != nil {
+		return nil, fmt.Errorf("validation failed: %w", err)
+	}
+
+	// UserID should be set by the handler from context before calling this service method.
+    if data.UserID == "" {
+        return nil, errors.New("userID is required in expense record data")
+    }
+
+	// For new records, ensure CreatedAt and UpdatedAt are set.
+	// ID will be set by the repository.
+	data.CreatedAt = time.Now()
+	data.UpdatedAt = time.Now()
+
+	// Potentially check for duplicates if necessary, though not explicitly in BankAccountService example for Create.
+	// Example:
+	// filter := map[string]interface{}{
+	// 	"userId":     data.UserID,
+	// 	"category":   data.Category,
+	// 	"dueDate":    data.DueDate,
+	// 	"amount":     data.Amount,
+	// }
+	// existing, err := s.Repo.GetExpenseRecordsByFilter(ctx, filter)
+	// if err != nil && err.Error() != "expense record not found" { // Assuming "not found" is a distinct error
+	// 	return nil, fmt.Errorf("error checking for existing expense record: %w", err)
+	// }
+	// if len(existing) > 0 {
+	// 	return nil, errors.New("an identical expense record already exists")
+	// }
+
+	return s.Repo.CreateExpenseRecord(ctx, data)
+}
+
+// GetExpenseRecordByID retrieves an expense record by its ID, ensuring user authorization.
+func (s *ExpenseRecordService) GetExpenseRecordByID(ctx context.Context, id string) (*entity_finance.ExpenseRecord, error) {
+	if id == "" {
+		return nil, errors.New("id is empty")
+	}
+
+	record, err := s.Repo.GetExpenseRecordByID(ctx, id)
+	if err != nil {
+		return nil, err // Handles "not found" from repository
+	}
+
+	// Authorization: Ensure the record belongs to the user in context.
+	// This assumes UserID is correctly populated in the record and available in context.
+	userIDFromCtx := ctx.Value("UserID")
+	if userIDFromCtx == nil || record.UserID != userIDFromCtx.(string) {
+		// Log this attempt, could be a security issue or bug
+		// log.Printf("Authorization failed: User %v attempted to access record %s owned by %s", userIDFromCtx, id, record.UserID)
+		return nil, errors.New("expense record not found or access denied") // Generic message for security
+	}
+
+	return record, nil
+}
+
+// GetExpenseRecords retrieves all expense records for the authenticated user.
+func (s *ExpenseRecordService) GetExpenseRecords(ctx context.Context) ([]entity_finance.ExpenseRecord, error) {
+	userIDFromCtx := ctx.Value("UserID")
+	if userIDFromCtx == nil || userIDFromCtx.(string) == "" {
+		return nil, errors.New("userID not found in context")
+	}
+
+	filter := map[string]interface{}{
+		"userId": userIDFromCtx.(string),
+	}
+
+	records, err := s.Repo.GetExpenseRecordsByFilter(ctx, filter)
+	if err != nil {
+		// If the error is because no records were found, it might be better to return an empty slice and no error.
+		// This depends on the desired API contract. For now, mirroring BankAccount which returns "not found".
+		return nil, err
+	}
+	// if len(records) == 0 { // This check might be redundant if repo returns specific "not found" error
+	// 	return nil, errors.New("no expense records found for the user")
+	// }
+	return records, nil
+}
+
+// GetExpenseRecordsByFilter retrieves expense records based on a filter for the authenticated user.
+func (s *ExpenseRecordService) GetExpenseRecordsByFilter(ctx context.Context, filter map[string]interface{}) ([]entity_finance.ExpenseRecord, error) {
+	if filter == nil {
+		return nil, errors.New("filter data is nil")
+	}
+	userIDFromCtx := ctx.Value("UserID")
+	if userIDFromCtx == nil || userIDFromCtx.(string) == "" {
+		return nil, errors.New("userID not found in context")
+	}
+
+	// Ensure the filter always includes the UserID from context to scope results.
+	filter["userId"] = userIDFromCtx.(string)
+
+	records, err := s.Repo.GetExpenseRecordsByFilter(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	// if len(records) == 0 { // Similar to GetExpenseRecords, decide if "not found" is an error or empty slice.
+	// 	return nil, errors.New("no expense records found matching the filter for the user")
+	// }
+	return records, nil
+}
+
+// UpdateExpenseRecord handles updating an existing expense record.
+func (s *ExpenseRecordService) UpdateExpenseRecord(ctx context.Context, id string, data *entity_finance.ExpenseRecord) (*entity_finance.ExpenseRecord, error) {
+	if id == "" {
+		return nil, errors.New("id is empty for update")
+	}
+	if data == nil {
+		return nil, errors.New("expense record data for update is nil")
+	}
+
+	if err := data.Validate(); err != nil {
+		return nil, fmt.Errorf("validation failed for update: %w", err)
+	}
+
+	// UserID should be set by the handler from context before calling this service method.
+    // It should match the original record's UserID and the UserID in context.
+    userIDFromCtx := ctx.Value("UserID")
+    if userIDFromCtx == nil || data.UserID != userIDFromCtx.(string) {
+        return nil, errors.New("user ID mismatch or not found in context for update")
+    }
+
+
+	// First, retrieve the existing record to ensure it exists and belongs to the user.
+	existingRecord, err := s.Repo.GetExpenseRecordByID(ctx, id)
+	if err != nil {
+		return nil, err // Handles "not found" from repository
+	}
+
+	if existingRecord.UserID != data.UserID { // Also check against UserID from context
+		// log.Printf("Authorization failed for update: User %v attempted to update record %s owned by %s", data.UserID, id, existingRecord.UserID)
+		return nil, errors.New("expense record not found or access denied for update")
+	}
+
+	// Ensure critical fields like ID and UserID are not changed by the update payload directly,
+	// or are consistent.
+	data.ID = existingRecord.ID // Preserve original ID
+	data.UserID = existingRecord.UserID // Preserve original UserID
+	data.CreatedAt = existingRecord.CreatedAt // Preserve original CreatedAt
+	data.UpdatedAt = time.Now() // Update timestamp
+
+	return s.Repo.UpdateExpenseRecord(ctx, id, data)
+}
+
+// DeleteExpenseRecord handles deleting an expense record.
+func (s *ExpenseRecordService) DeleteExpenseRecord(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("id is empty for delete")
+	}
+
+	userIDFromCtx := ctx.Value("UserID")
+	if userIDFromCtx == nil || userIDFromCtx.(string) == "" {
+		return errors.New("userID not found in context for delete")
+	}
+
+	// Retrieve the record first to ensure it belongs to the user.
+	recordToVerify, err := s.Repo.GetExpenseRecordByID(ctx, id)
+	if err != nil {
+		return err // Handles "not found" from repository, which is fine.
+	}
+
+	if recordToVerify.UserID != userIDFromCtx.(string) {
+		// log.Printf("Authorization failed for delete: User %v attempted to delete record %s owned by %s", userIDFromCtx, id, recordToVerify.UserID)
+		return errors.New("expense record not found or access denied for delete")
+	}
+
+	return s.Repo.DeleteExpenseRecord(ctx, id)
+}

--- a/internal/core/service/finance/expenseRecord_test.go
+++ b/internal/core/service/finance/expenseRecord_test.go
@@ -1,0 +1,11 @@
+package service_finance
+
+import (
+	"testing"
+)
+
+// Basic test structure. Full tests require mocking ExpenseRecordRepositoryInterface.
+func TestExpenseRecordService_Placeholder(t *testing.T) {
+	// TODO: Add actual tests with mocks
+	t.Log("Placeholder test for ExpenseRecordService. Further tests require repository mocking.")
+}

--- a/internal/handler/web/finance/expenseRecord.go
+++ b/internal/handler/web/finance/expenseRecord.go
@@ -1,0 +1,396 @@
+package web_finance
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	entity_finance "github.com/Tomelin/dashfin-backend-app/internal/core/entity/finance"
+	web "github.com/Tomelin/dashfin-backend-app/internal/handler/web"
+	"github.com/Tomelin/dashfin-backend-app/pkg/authenticatior"
+	cryptdata "github.com/Tomelin/dashfin-backend-app/pkg/cryptData"
+	"github.com/gin-gonic/gin"
+)
+
+// ExpenseRecordHandlerInterface defines the HTTP handler operations for ExpenseRecords.
+type ExpenseRecordHandlerInterface interface {
+	CreateExpenseRecord(c *gin.Context)
+	GetExpenseRecordByID(c *gin.Context)
+	GetExpenseRecords(c *gin.Context)
+	GetExpenseRecordsByFilter(c *gin.Context) // Added for filtering
+	UpdateExpenseRecord(c *gin.Context)
+	DeleteExpenseRecord(c *gin.Context)
+}
+
+// ExpenseRecordHandler handles HTTP requests for ExpenseRecords.
+type ExpenseRecordHandler struct {
+	service     entity_finance.ExpenseRecordServiceInterface
+	router      *gin.RouterGroup // Keep if you intend to use it directly, otherwise can be passed in setupRoutes
+	encryptData cryptdata.CryptDataInterface
+	authClient  authenticatior.Authenticator
+}
+
+// InitializeExpenseRecordHandler creates a new ExpenseRecordHandler and sets up routes.
+func InitializeExpenseRecordHandler(
+	svc entity_finance.ExpenseRecordServiceInterface,
+	encryptData cryptdata.CryptDataInterface,
+	authClient authenticatior.Authenticator,
+	routerGroup *gin.RouterGroup,
+	middleware ...gin.HandlerFunc,
+) ExpenseRecordHandlerInterface {
+	handler := &ExpenseRecordHandler{
+		service:     svc,
+		encryptData: encryptData,
+		authClient:  authClient,
+		// router: routerGroup, // Not strictly needed if routerGroup is only used in setupRoutes
+	}
+
+	handler.setupRoutes(routerGroup, middleware...)
+	return handler
+}
+
+func (h *ExpenseRecordHandler) setupRoutes(routerGroup *gin.RouterGroup, middleware ...gin.HandlerFunc) {
+	// Apply provided middleware to the group or individual routes
+	// For simplicity, applying to all routes here.
+	// You might want more granular control.
+	// Example: financeRoutes := routerGroup.Group("/finance/expense-records", middleware...)
+
+	financeRoutes := routerGroup.Group("/finance/expense-records")
+	for _, mw := range middleware {
+		financeRoutes.Use(mw)
+	}
+
+	financeRoutes.POST("", h.CreateExpenseRecord)
+	financeRoutes.GET("/:id", h.GetExpenseRecordByID)
+	financeRoutes.GET("", h.GetExpenseRecords)      // Get all for user
+	financeRoutes.POST("/filter", h.GetExpenseRecordsByFilter) // Route for filtered GET
+	financeRoutes.PUT("/:id", h.UpdateExpenseRecord)
+	financeRoutes.DELETE("/:id", h.DeleteExpenseRecord)
+}
+
+// CreateExpenseRecord handles the creation of a new expense record.
+func (h *ExpenseRecordHandler) CreateExpenseRecord(c *gin.Context) {
+	userID, token, err := web.GetRequiredHeaders(h.authClient, c.Request)
+	if err != nil {
+		log.Printf("Error getting required headers: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var payload cryptdata.CryptData
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		log.Printf("Error binding JSON payload: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload: " + err.Error()})
+		return
+	}
+
+	decryptedData, err := h.encryptData.PayloadData(payload.Payload)
+	if err != nil {
+		log.Printf("Error decrypting payload data: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Error processing request data: " + err.Error()})
+		return
+	}
+
+	var expenseRecord entity_finance.ExpenseRecord
+	if err := json.Unmarshal(decryptedData, &expenseRecord); err != nil {
+		log.Printf("Error unmarshalling decrypted data to ExpenseRecord: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid data format: " + err.Error()})
+		return
+	}
+
+    // Set UserID from authenticated user
+    expenseRecord.UserID = userID
+
+	ctx := context.WithValue(c.Request.Context(), "Authorization", token)
+	ctx = context.WithValue(ctx, "UserID", userID)
+
+	result, err := h.service.CreateExpenseRecord(ctx, &expenseRecord)
+	if err != nil {
+		log.Printf("Error creating expense record via service: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create expense record: " + err.Error()})
+		return
+	}
+
+	responseBytes, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("Error marshalling result to JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error preparing response: " + err.Error()})
+		return
+	}
+
+	encryptedResult, err := h.encryptData.EncryptPayload(responseBytes)
+	if err != nil {
+		log.Printf("Error encrypting response payload: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error securing response: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"payload": encryptedResult})
+}
+
+// GetExpenseRecordByID handles fetching a single expense record by its ID.
+func (h *ExpenseRecordHandler) GetExpenseRecordByID(c *gin.Context) {
+	userID, token, err := web.GetRequiredHeaders(h.authClient, c.Request)
+	if err != nil {
+		log.Printf("Error getting required headers: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID parameter is required"})
+		return
+	}
+
+	ctx := context.WithValue(c.Request.Context(), "Authorization", token)
+	ctx = context.WithValue(ctx, "UserID", userID)
+
+	result, err := h.service.GetExpenseRecordByID(ctx, id)
+	if err != nil {
+		log.Printf("Error getting expense record by ID via service (ID: %s): %v", id, err)
+		// Distinguish between "not found" and other errors if possible
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "access denied") {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve expense record: " + err.Error()})
+		}
+		return
+	}
+
+	responseBytes, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("Error marshalling result to JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error preparing response: " + err.Error()})
+		return
+	}
+
+	encryptedResult, err := h.encryptData.EncryptPayload(responseBytes)
+	if err != nil {
+		log.Printf("Error encrypting response payload: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error securing response: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"payload": encryptedResult})
+}
+
+// GetExpenseRecords handles fetching all expense records for the authenticated user.
+func (h *ExpenseRecordHandler) GetExpenseRecords(c *gin.Context) {
+	userID, token, err := web.GetRequiredHeaders(h.authClient, c.Request)
+	if err != nil {
+		log.Printf("Error getting required headers: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx := context.WithValue(c.Request.Context(), "Authorization", token)
+	ctx = context.WithValue(ctx, "UserID", userID)
+
+	results, err := h.service.GetExpenseRecords(ctx)
+	if err != nil {
+		log.Printf("Error getting expense records via service: %v", err)
+         // If service returns "not found" for an empty list, handle it gracefully
+        if strings.Contains(err.Error(), "not found") {
+             c.JSON(http.StatusOK, gin.H{"payload": "[]"}) // Return empty JSON array
+             return
+        }
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve expense records: " + err.Error()})
+		return
+	}
+
+    // Handle case where results might be nil from service if no records found (and no error)
+    if results == nil {
+        results = []entity_finance.ExpenseRecord{} // Ensure a non-nil slice for marshalling
+    }
+
+
+	responseBytes, err := json.Marshal(results)
+	if err != nil {
+		log.Printf("Error marshalling results to JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error preparing response: " + err.Error()})
+		return
+	}
+
+	encryptedResult, err := h.encryptData.EncryptPayload(responseBytes)
+	if err != nil {
+		log.Printf("Error encrypting response payload: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error securing response: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"payload": encryptedResult})
+}
+
+// GetExpenseRecordsByFilter handles fetching expense records based on a filter.
+func (h *ExpenseRecordHandler) GetExpenseRecordsByFilter(c *gin.Context) {
+	userID, token, err := web.GetRequiredHeaders(h.authClient, c.Request)
+	if err != nil {
+		log.Printf("Error getting required headers: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var payload cryptdata.CryptData
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		log.Printf("Error binding JSON payload for filter: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload for filter: " + err.Error()})
+		return
+	}
+
+	decryptedData, err := h.encryptData.PayloadData(payload.Payload)
+	if err != nil {
+		log.Printf("Error decrypting payload data for filter: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Error processing request data for filter: " + err.Error()})
+		return
+	}
+
+	var filter map[string]interface{}
+	if err := json.Unmarshal(decryptedData, &filter); err != nil {
+		log.Printf("Error unmarshalling decrypted data to filter map: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid filter data format: " + err.Error()})
+		return
+	}
+
+	ctx := context.WithValue(c.Request.Context(), "Authorization", token)
+	ctx = context.WithValue(ctx, "UserID", userID)
+
+	results, err := h.service.GetExpenseRecordsByFilter(ctx, filter)
+	if err != nil {
+		log.Printf("Error getting expense records by filter via service: %v", err)
+        if strings.Contains(err.Error(), "not found") {
+             c.JSON(http.StatusOK, gin.H{"payload": "[]"}) // Return empty JSON array
+             return
+        }
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve expense records by filter: " + err.Error()})
+		return
+	}
+
+    if results == nil {
+        results = []entity_finance.ExpenseRecord{}
+    }
+
+	responseBytes, err := json.Marshal(results)
+	if err != nil {
+		log.Printf("Error marshalling filtered results to JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error preparing response: " + err.Error()})
+		return
+	}
+
+	encryptedResult, err := h.encryptData.EncryptPayload(responseBytes)
+	if err != nil {
+		log.Printf("Error encrypting response payload: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error securing response: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"payload": encryptedResult})
+}
+
+
+// UpdateExpenseRecord handles updating an existing expense record.
+func (h *ExpenseRecordHandler) UpdateExpenseRecord(c *gin.Context) {
+	userID, token, err := web.GetRequiredHeaders(h.authClient, c.Request)
+	if err != nil {
+		log.Printf("Error getting required headers: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID parameter is required for update"})
+		return
+	}
+
+	var payload cryptdata.CryptData
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		log.Printf("Error binding JSON payload for update: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload for update: " + err.Error()})
+		return
+	}
+
+	decryptedData, err := h.encryptData.PayloadData(payload.Payload)
+	if err != nil {
+		log.Printf("Error decrypting payload data for update: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Error processing request data for update: " + err.Error()})
+		return
+	}
+
+	var expenseRecord entity_finance.ExpenseRecord
+	if err := json.Unmarshal(decryptedData, &expenseRecord); err != nil {
+		log.Printf("Error unmarshalling decrypted data to ExpenseRecord for update: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid data format for update: " + err.Error()})
+		return
+	}
+
+    // Set UserID from authenticated user for the update payload
+    expenseRecord.UserID = userID
+
+
+	ctx := context.WithValue(c.Request.Context(), "Authorization", token)
+	ctx = context.WithValue(ctx, "UserID", userID)
+
+	// The service's UpdateExpenseRecord should handle verifying ownership and setting UpdatedAt.
+	// Pass the ID from the path and the unmarshalled data.
+	result, err := h.service.UpdateExpenseRecord(ctx, id, &expenseRecord)
+	if err != nil {
+		log.Printf("Error updating expense record via service (ID: %s): %v", id, err)
+        if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "access denied") {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update expense record: " + err.Error()})
+		}
+		return
+	}
+
+	responseBytes, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("Error marshalling updated result to JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error preparing response: " + err.Error()})
+		return
+	}
+
+	encryptedResult, err := h.encryptData.EncryptPayload(responseBytes)
+	if err != nil {
+		log.Printf("Error encrypting response payload: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error securing response: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"payload": encryptedResult})
+}
+
+// DeleteExpenseRecord handles deleting an expense record.
+func (h *ExpenseRecordHandler) DeleteExpenseRecord(c *gin.Context) {
+	userID, token, err := web.GetRequiredHeaders(h.authClient, c.Request)
+	if err != nil {
+		log.Printf("Error getting required headers: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID parameter is required for delete"})
+		return
+	}
+
+	ctx := context.WithValue(c.Request.Context(), "Authorization", token)
+	ctx = context.WithValue(ctx, "UserID", userID)
+
+	err = h.service.DeleteExpenseRecord(ctx, id)
+	if err != nil {
+		log.Printf("Error deleting expense record via service (ID: %s): %v", id, err)
+        if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "access denied"){
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete expense record: " + err.Error()})
+		}
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}


### PR DESCRIPTION
This commit introduces the full CRUD (Create, Read, Update, Delete) functionality for managing expense records.

Key changes include:
- **ExpenseRecord Entity:** Defined in `internal/core/entity/finance/expenseRecord.go`, including validation logic based on the provided contract.
- **ExpenseRecord Repository:** Implemented in `internal/core/repository/finance/expenseRecord.go`, using Firebase as the database backend.
- **ExpenseRecord Service:** Implemented in `internal/core/service/finance/expenseRecord.go`, containing business logic for expense record operations and ensuring your ownership of data.
- **ExpenseRecord Handler:** Implemented in `internal/handler/web/finance/expenseRecord.go`, providing REST API endpoints for `/finance/expense-records`. Includes data encryption/decryption and authentication.
- **Dependency Registration:** Updated `cmd/main.go` to initialize and wire up the new components.
- **Unit Tests:** Added basic unit tests, primarily focusing on entity validation. Placeholder tests are included for repository and service layers, which would require further mocking for comprehensive testing.

The API endpoints follow the patterns established by the existing BankAccount feature, including payload encryption and user authentication.