### PR TITLE
feat: Implement mailer library for Google Cloud

### DIFF
--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -1,0 +1,31 @@
+package mailer
+
+import (
+	"net/http"
+
+	"google.golang.org/appengine/v2"
+	"google.golang.org/appengine/v2/mail"
+)
+
+// Mailer is an empty struct.
+type Mailer struct{}
+
+// NewMailer returns a new instance of the Mailer struct.
+func NewMailer() *Mailer {
+	return &Mailer{}
+}
+
+// SendEmail sends an email using the App Engine mail service.
+func (m *Mailer) SendEmail(r *http.Request, sender string, recipient []string, subject string, body string) error {
+	ctx := appengine.NewContext(r)
+	msg := &mail.Message{
+		Sender:  sender,
+		To:      recipient,
+		Subject: subject,
+		Body:    body,
+	}
+	if err := mail.Send(ctx, msg); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This commit introduces a new mailer library in `pkg/mailer` for sending emails via Google Cloud App Engine.

The library includes:
- A `Mailer` struct.
- A `NewMailer` function to instantiate the mailer.
- A `SendEmail` method that utilizes the `google.golang.org/appengine/v2/mail` package to send emails. The method requires an `http.Request` to create the necessary `appengine.Context`.

A basic test structure for `SendEmail` was added in `pkg/mailer/mailer_test.go`. However, I was not able to execute these tests due to an internal issue with `dev_appserver.py` in the testing environment related to a Python `NameError` in `httplib2`.